### PR TITLE
Fix double free bug in Loader::close()

### DIFF
--- a/src/xsi_loader.cpp
+++ b/src/xsi_loader.cpp
@@ -89,6 +89,7 @@ Loader::close()
     for(XSI_INT32 i=0; i<size; ++i) {
         delete[] _xsi_value_buffer[i];
     }
+    _xsi_value_buffer.clear();
 
     if (_design_handle) {
         _xsi_close(_design_handle);


### PR DESCRIPTION
`_xsi_value_buffer` itself is a vector of pointers, whose entries are not popped. Then during a second call to close() the vector size is unchanged and it still contains pointers but to the previously deleted arrays. This causes the code to enter the for loop again and try to delete[] the memory behind the pointers a second time.

Fix this by explicitly emptying the vector.