### PR TITLE
Make Docker optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 XILINX_VIVADO ?= /opt/xilinx/Vivado/2023.2
+PYXSI_MAKE_USE_DOCKER ?= 1
 
+LAUNCH_DOCKER =
+ifeq ($(PYXSI_MAKE_USE_DOCKER),1)
 # See if we're inside docker. If not, wrap ourselves in docker and try again.
 ifeq ($(wildcard /.dockerenv),)
+LAUNCH_DOCKER = 1
+endif
+endif
+
+ifdef LAUNCH_DOCKER
 include Makefile.docker-boilerplate
 else
 # For the remainder of this Makefile, we're running within Docker and can focus


### PR DESCRIPTION
The makefile wraps itself in a Docker container when it is not already running in a container. However, we use FINN in environments where Docker is not available.

Instead of working around this by creating a fake "/.dockerenv" file, we would like to disable this behavior via an env var passed to make.